### PR TITLE
feat(config): adopt builder pattern for `FunPlusConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,55 @@
 
 ### Install the SDK
 
-Modify your `AppDelegate.swift` file as below code snippet demonstrates.
+Put the following initialization codes in your project. Usually the `application:didFinishLaunchingWithOptions` delegate method is a good place to put the codes in.
 
 ```swift
 import FunPlusSDK
 
-let APP_ID = "test"
-let APP_KEY = "funplus"
+let APP_ID = "{YourAppId}"
+let APP_KEY = "{YourAppKey}"
 let RUM_TAG = "{YourRumTag}"
 let RUM_KEY = "{YourRumKey}"
 let ENV = SDKEnvironment.sandbox	// sandbox/production
 
-func application(_ application: UIApplication, didFinishLaunchingWithOptions
-	launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    FunPlusSDK.install(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
-}
+FunPlusSDK.install(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
 ```
+
+Now you've done initializing the SDK.
+
+### Config the SDK
+
+You may want to override SDK's default config values. In such a case, you need to initialize the SDK in a different way, as the following code snippet illustrates.
+
+```swift
+import FunPlusSDK
+
+let APP_ID = "{YourAppId}"
+let APP_KEY = "{YourAppKey}"
+let RUM_TAG = "{YourRumTag}"
+let RUM_KEY = "{YourRumKey}"
+let ENV = SDKEnvironment.sandbox	// sandbox/production
+
+let funPlusConfig = FunPlusConfig(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
+
+funPlusConfig.setRumUploadInterval(10)
+             .setAutoSessionStartAndEnd(false)
+             .end()
+
+FunPlusSDK.install(funPlusConfig: funPlusConfig)
+```
+
+Here's all the config values that can be overrided.
+
+| name                   | type     | description                              |
+| ---------------------- | -------- | ---------------------------------------- |
+| rumUploadInterval      | Int64    | This value indicates a time interval to trigger a RUM events uploading process. Default is 30. |
+| rumSampleRate          | Double   | This value indicates percentage of RUM events to be traced for sampling. Default is 1.0. |
+| rumEventWhitelist      | [String] | RUM events in this array will always be traced. Default is an empty array. |
+| rumUserWhitelist       | [String] | RUM events produced by users in this array will always be traced. Default is an empty array. |
+| rumUserBlacklist       | [String] | RUM events produced by users in this array will never be traced. `rumUesrWhitelist` will be checked before this array. Default is an empty array. |
+| dataUploadInterval     | Int64    | This value indicates a time interval to trigger a Data events uploading process. Default is 30. |
+| autoSessionStartAndEnd | Bool     | If set true, SDK will automatically trigger session starting and session ending. Default is true. |
 
 ## Usage
 

--- a/Source/FunPlusConfig.swift
+++ b/Source/FunPlusConfig.swift
@@ -25,26 +25,28 @@ public class FunPlusConfig {
     let loggerTag: String
     let loggerKey: String
     let logLevel: LogLevel
-    let loggerUploadInterval: Int64
+    var loggerUploadInterval: Int64
     
     let rumEndpoint: String
     let rumTag: String
     let rumKey: String
-    let rumUploadInterval: Int64
+    var rumUploadInterval: Int64
     
-    let rumSampleRate: Double
-    let rumEventWhitelist: [String]
-    let rumUserWhitelist: [String]
-    let rumUserBlacklist: [String]
+    var rumSampleRate: Double
+    var rumEventWhitelist: [String]
+    var rumUserWhitelist: [String]
+    var rumUserBlacklist: [String]
     
     let dataEndpoint: String
     let dataTag: String
     let dataKey: String
-    let dataUploadInterval: Int64
+    var dataUploadInterval: Int64
+
+    var autoSessionStartAndEnd: Bool
     
     // MARK: - Init
     
-    init(appId: String, appKey: String, rumTag: String, rumKey: String, environment: SDKEnvironment) {
+    public init(appId: String, appKey: String, rumTag: String, rumKey: String, environment: SDKEnvironment) {
         self.appId = appId
         self.appKey = appKey
         self.environment = environment
@@ -71,6 +73,8 @@ public class FunPlusConfig {
         self.dataTag = appId
         self.dataKey = appKey
         self.dataUploadInterval = 30    // 30 sec
+        
+        self.autoSessionStartAndEnd = true
     }
     
     // Deprecated
@@ -129,5 +133,55 @@ public class FunPlusConfig {
         self.dataTag = dataTag
         self.dataKey = dataKey
         self.dataUploadInterval = configDict["data_upload_interval"] as? Int64 ?? 10
+        
+        self.autoSessionStartAndEnd = true
+    }
+    
+    public func setLoggerUploadInterval(_ value: Int64) -> FunPlusConfig {
+        loggerUploadInterval = value
+        return self
+    }
+    
+    public func setRumUploadInterval(_ value: Int64) -> FunPlusConfig {
+        rumUploadInterval = value
+        return self
+    }
+    
+    public func setRumSampleRate(_ value: Double) -> FunPlusConfig {
+        rumSampleRate = value
+        return self
+    }
+    
+    public func setRumEventWhitelist(_ value: [String]) -> FunPlusConfig {
+        rumEventWhitelist = value
+        return self
+    }
+    
+    public func setRumUserWhitelist(_ value: [String]) -> FunPlusConfig {
+        rumUserWhitelist = value
+        return self
+    }
+    
+    public func setRumUserBlacklist(_ value: [String]) -> FunPlusConfig {
+        rumUserBlacklist = value
+        return self
+    }
+    
+    public func setDataUploadInterval(_ value: Int64) -> FunPlusConfig {
+        dataUploadInterval = value
+        return self
+    }
+    
+    public func setAutoSessionStartAndEnd(_ value: Bool) -> FunPlusConfig {
+        autoSessionStartAndEnd = value
+        return self
+    }
+    
+    ///
+    /// This method should be called at the end of the settings chain,
+    /// in order to avoid compiler's "unused returning value" warning.
+    ///
+    public func end() {
+        // Do nothing
     }
 }

--- a/Source/FunPlusSDK.swift
+++ b/Source/FunPlusSDK.swift
@@ -40,7 +40,6 @@ public class FunPlusSDK {
     
     // MARK: - Install & Init
     
-    // Deprecated
     public class func install(funPlusConfig: FunPlusConfig) {
         if instance == nil {
             print("[FunPlusSDK] Installing FunPlus SDK: {sdkVersion=\(FunPlusSDK.VERSION), appId=\(funPlusConfig.appId), env=\(funPlusConfig.environment)}")

--- a/Tests/FunPlusConfigTests.swift
+++ b/Tests/FunPlusConfigTests.swift
@@ -13,56 +13,130 @@ class FunPlusConfigTests: XCTestCase {
     
     let APP_ID = "test"
     let APP_KEY = "funpuls"
-    let CONFIG_ETAG = ""
+    let RUM_TAG = "test"
+    let RUM_KEY = "funplus"
     let ENV = SDKEnvironment.sandbox
     
-    func testInit() {
-        // Given
-        let configDict: [String: Any] = [
-            "logger_endpoint": "https://logagent.infra.funplus.net/log",
-            "logger_tag": "test",
-            "logger_key": "funplus",
-            "logger_level": "info",
-            "rum_endpoint": "https://logagent.infra.funplus.net/log",
-            "rum_tag": "test",
-            "rum_key": "funplus",
-            "data_endpoint": "https://logagent.infra.funplus.net/log",
-            "data_tag": "test",
-            "data_key": "funplus",
-            "adjust_app_token": "cchqrhzyr4zu",
-            "adjust_app_open_event_token": "st1hu7"
-        ]
-        var funPlusConfig: FunPlusConfig?
-        var err: FunPlusSDKError? = nil
-        
-        // When
-        do {
-            funPlusConfig = try FunPlusConfig(appId: APP_ID, appKey: APP_KEY, environment: ENV, configEtag: CONFIG_ETAG, configDict: configDict)
-        } catch {
-            err = FunPlusSDKError.invalidConfig
-        }
+    let DEFAULT_LOGGER_UPLOAD_INTERVAL: Int64 = 60
+    let DEFAULT_RUM_UPLOAD_INTERVAL: Int64 = 30
+    let DEFAULT_DATA_UPLOAD_INTERVAL: Int64 = 30
+    let DEFAULT_RUM_SAMPLE_RATE = 1.0
+    
+    func testDefaultValuesForSandboxEnvironment() {
+        // Given, When
+        let config = FunPlusConfig(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
         
         // Then
-        XCTAssertNotNil(funPlusConfig)
-        XCTAssertNil(err)
+        XCTAssertEqual(config.appId, APP_ID, "appId should be \(APP_ID)")
+        XCTAssertEqual(config.appKey, APP_KEY, "appKey should be \(APP_KEY)")
+        XCTAssertEqual(config.environment, ENV, "environment should be \(ENV)")
+        
+        XCTAssertEqual(config.loggerEndpoint, FunPlusConfig.LOG_SERVER, "loggerEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.loggerTag, RUM_TAG, "loggerTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.loggerKey, RUM_KEY, "loggerKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.logLevel, LogLevel.info, "logLevel should be \(LogLevel.info)")
+        XCTAssertEqual(config.loggerUploadInterval, DEFAULT_LOGGER_UPLOAD_INTERVAL, "loggerUploadInterval should be \(DEFAULT_LOGGER_UPLOAD_INTERVAL)")
+        
+        XCTAssertEqual(config.rumEndpoint, FunPlusConfig.LOG_SERVER, "rumEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.rumTag, RUM_TAG, "rumTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.rumKey, RUM_KEY, "rumKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.rumUploadInterval, DEFAULT_RUM_UPLOAD_INTERVAL, "rumUploadInterval should be \(DEFAULT_RUM_UPLOAD_INTERVAL)")
+        
+        XCTAssertEqual(config.rumSampleRate, DEFAULT_RUM_SAMPLE_RATE, "rumSampleRate should be \(DEFAULT_RUM_SAMPLE_RATE)")
+        XCTAssertTrue(config.rumEventWhitelist.isEmpty, "rumEventWhitelist should be empty")
+        XCTAssertTrue(config.rumUserWhitelist.isEmpty, "rumUserWhitelist should be empty")
+        XCTAssertTrue(config.rumUserBlacklist.isEmpty, "rumUserBlacklist should be empty")
+        
+        XCTAssertEqual(config.dataEndpoint, FunPlusConfig.LOG_SERVER, "dataEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.dataTag, APP_ID, "dataTag should be \(APP_ID)")
+        XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
+        XCTAssertEqual(config.dataUploadInterval, DEFAULT_DATA_UPLOAD_INTERVAL, "dataUploadInterval should be \(DEFAULT_DATA_UPLOAD_INTERVAL)")
+        
+        XCTAssertTrue(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be true")
     }
     
-    func testBadInit() {
-        // Given
-        let configDict = [String: Any]()
-        var funPlusConfig: FunPlusConfig?
-        var err: FunPlusSDKError? = nil
-        
-        // When
-        do {
-            funPlusConfig = try FunPlusConfig(appId: APP_ID, appKey: APP_KEY, environment: ENV, configEtag: CONFIG_ETAG, configDict: configDict)
-        } catch {
-            err = FunPlusSDKError.invalidConfig
-        }
+    func testDefaultValuesForProductionEnvironment() {
+        // Given, When
+        let config = FunPlusConfig(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
         
         // Then
-        XCTAssertNil(funPlusConfig)
-        XCTAssertNotNil(err)
+        XCTAssertEqual(config.appId, APP_ID, "appId should be \(APP_ID)")
+        XCTAssertEqual(config.appKey, APP_KEY, "appKey should be \(APP_KEY)")
+        XCTAssertEqual(config.environment, ENV, "environment should be \(ENV)")
+        
+        XCTAssertEqual(config.loggerEndpoint, FunPlusConfig.LOG_SERVER, "loggerEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.loggerTag, RUM_TAG, "loggerTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.loggerKey, RUM_KEY, "loggerKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.logLevel, LogLevel.info, "logLevel should be \(LogLevel.error)")
+        XCTAssertEqual(config.loggerUploadInterval, DEFAULT_LOGGER_UPLOAD_INTERVAL, "loggerUploadInterval should be \(DEFAULT_LOGGER_UPLOAD_INTERVAL)")
+        
+        XCTAssertEqual(config.rumEndpoint, FunPlusConfig.LOG_SERVER, "rumEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.rumTag, RUM_TAG, "rumTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.rumKey, RUM_KEY, "rumKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.rumUploadInterval, DEFAULT_RUM_UPLOAD_INTERVAL, "rumUploadInterval should be \(DEFAULT_RUM_UPLOAD_INTERVAL)")
+        
+        XCTAssertEqual(config.rumSampleRate, DEFAULT_RUM_SAMPLE_RATE, "rumSampleRate should be \(DEFAULT_RUM_SAMPLE_RATE)")
+        XCTAssertTrue(config.rumEventWhitelist.isEmpty, "rumEventWhitelist should be empty")
+        XCTAssertTrue(config.rumUserWhitelist.isEmpty, "rumUserWhitelist should be empty")
+        XCTAssertTrue(config.rumUserBlacklist.isEmpty, "rumUserBlacklist should be empty")
+        
+        XCTAssertEqual(config.dataEndpoint, FunPlusConfig.LOG_SERVER, "dataEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.dataTag, APP_ID, "dataTag should be \(APP_ID)")
+        XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
+        XCTAssertEqual(config.dataUploadInterval, DEFAULT_DATA_UPLOAD_INTERVAL, "dataUploadInterval should be \(DEFAULT_DATA_UPLOAD_INTERVAL)")
+        
+        XCTAssertTrue(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be true")
+    }
+    
+    func testSettersChain() {
+        // Given
+        let loggerUploadInterval: Int64 = 10
+        let rumUploadInterval: Int64 = 5
+        let rumSampleRate = 0.8
+        let rumEventWhitelist = ["level_up", "money_gain"]
+        let rumUserWhitelist = ["user1", "user2", "user3"]
+        let rumUserBlacklist = ["user4", "user5"]
+        let dataUploadInterval: Int64 = 6
+        let config = FunPlusConfig(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
+        
+        // When
+        config.setLoggerUploadInterval(loggerUploadInterval)
+            .setRumUploadInterval(rumUploadInterval)
+            .setRumSampleRate(rumSampleRate)
+            .setRumEventWhitelist(rumEventWhitelist)
+            .setRumUserWhitelist(rumUserWhitelist)
+            .setRumUserBlacklist(rumUserBlacklist)
+            .setDataUploadInterval(dataUploadInterval)
+            .setAutoSessionStartAndEnd(false)
+            .end()
+        
+        // Then
+        XCTAssertEqual(config.appId, APP_ID, "appId should be \(APP_ID)")
+        XCTAssertEqual(config.appKey, APP_KEY, "appKey should be \(APP_KEY)")
+        XCTAssertEqual(config.environment, ENV, "environment should be \(ENV)")
+        
+        XCTAssertEqual(config.loggerEndpoint, FunPlusConfig.LOG_SERVER, "loggerEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.loggerTag, RUM_TAG, "loggerTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.loggerKey, RUM_KEY, "loggerKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.logLevel, LogLevel.info, "logLevel should be \(LogLevel.info)")
+        XCTAssertEqual(config.loggerUploadInterval, loggerUploadInterval, "loggerUploadInterval should be \(loggerUploadInterval)")
+        
+        XCTAssertEqual(config.rumEndpoint, FunPlusConfig.LOG_SERVER, "rumEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.rumTag, RUM_TAG, "rumTag should be \(RUM_TAG)")
+        XCTAssertEqual(config.rumKey, RUM_KEY, "rumKey should be \(RUM_KEY)")
+        XCTAssertEqual(config.rumUploadInterval, rumUploadInterval, "rumUploadInterval should be \(rumUploadInterval)")
+        
+        XCTAssertEqual(config.rumSampleRate, rumSampleRate, "rumSampleRate should be \(rumSampleRate)")
+        XCTAssertEqual(config.rumEventWhitelist.count, 2, "rumEventWhitelist should contain 2 items")
+        XCTAssertEqual(config.rumUserWhitelist.count, 3, "rumUserWhitelist should contain 3 items")
+        XCTAssertEqual(config.rumUserBlacklist.count, 2, "rumUserBlacklist should contain 2 items")
+        
+        XCTAssertEqual(config.dataEndpoint, FunPlusConfig.LOG_SERVER, "dataEndpoint should be \(FunPlusConfig.LOG_SERVER)")
+        XCTAssertEqual(config.dataTag, APP_ID, "dataTag should be \(APP_ID)")
+        XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
+        XCTAssertEqual(config.dataUploadInterval, dataUploadInterval, "dataUploadInterval should be \(dataUploadInterval)")
+        
+        XCTAssertFalse(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be false")
     }
 
 }


### PR DESCRIPTION
In order to override SDK's default config values, a builder pattern is
introduced. Developer creates a new `FunPlusConfig` object and overrides
some config values, then uses this object to initialize the SDK.

Here's an example:

```
import FunPlusSDK

let APP_ID = "test"
let APP_KEY = "funplus"
let RUM_TAG = "{YourRumTag}"
let RUM_KEY = "{YourRumKey}"
let ENV = SDKEnvironment.sandbox

let funPlusConfig = FunPlusConfig(
    appId: APP_ID,
    appKey: APP_KEY,
    rumTag: RUM_TAG,
    rumKey: RUM_KEY,
    environment: ENV
)

funPlusConfig.setRumUploadInterval(10)
             .setAutoSessionStartAndEnd(false)
             ...
             .end()

FunPlusSDK.install(funPlusConfig: funPlusConfig)
```

Closes #6