### PR TITLE
feat(data): ability to turn off auto tracing of session events

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ let ENV = SDKEnvironment.sandbox	// sandbox/production
 let funPlusConfig = FunPlusConfig(appId: APP_ID, appKey: APP_KEY, rumTag: RUM_TAG, rumKey: RUM_KEY, environment: ENV)
 
 funPlusConfig.setRumUploadInterval(10)
-             .setAutoSessionStartAndEnd(false)
+             .setDataAutoTraceSessionEvents(false)
              .end()
 
 FunPlusSDK.install(funPlusConfig: funPlusConfig)
@@ -77,15 +77,15 @@ FunPlusSDK.install(funPlusConfig: funPlusConfig)
 
 Here's all the config values that can be overrided.
 
-| name                   | type     | description                              |
-| ---------------------- | -------- | ---------------------------------------- |
-| rumUploadInterval      | Int64    | This value indicates a time interval to trigger a RUM events uploading process. Default is 30. |
-| rumSampleRate          | Double   | This value indicates percentage of RUM events to be traced for sampling. Default is 1.0. |
-| rumEventWhitelist      | [String] | RUM events in this array will always be traced. Default is an empty array. |
-| rumUserWhitelist       | [String] | RUM events produced by users in this array will always be traced. Default is an empty array. |
-| rumUserBlacklist       | [String] | RUM events produced by users in this array will never be traced. `rumUesrWhitelist` will be checked before this array. Default is an empty array. |
-| dataUploadInterval     | Int64    | This value indicates a time interval to trigger a Data events uploading process. Default is 30. |
-| autoSessionStartAndEnd | Bool     | If set true, SDK will automatically trigger session starting and session ending. Default is true. |
+| name                       | type     | description                              |
+| -------------------------- | -------- | ---------------------------------------- |
+| rumUploadInterval          | Int64    | This value indicates a time interval to trigger a RUM events uploading process. Default is 30. |
+| rumSampleRate              | Double   | This value indicates percentage of RUM events to be traced for sampling. Default is 1.0. |
+| rumEventWhitelist          | [String] | RUM events in this array will always be traced. Default is an empty array. |
+| rumUserWhitelist           | [String] | RUM events produced by users in this array will always be traced. Default is an empty array. |
+| rumUserBlacklist           | [String] | RUM events produced by users in this array will never be traced. `rumUesrWhitelist` will be checked before this array. Default is an empty array. |
+| dataUploadInterval         | Int64    | This value indicates a time interval to trigger a Data events uploading process. Default is 30. |
+| dataAutoTraceSessionEvents | Bool     | If set true, SDK will automatically trace `session_start` and `session_end` events. Default is true. |
 
 ## Usage
 
@@ -221,6 +221,20 @@ FunPlusSDK.getFunPlusData().traceCustom(eventName:, properties:)
 FunPlusSDK.getFunPlusData().setExtraProperty(key: "{key}", value: "{value}");
 FunPlusSDK.getFunPlusData().eraseExtraProperty(key: "{key}");
 ```
+
+### Manually trace session events
+
+By default, SDK automatically traces the `session_start` and `session_end` events. This behavior can be changed by override the `dataAutoTraceSessionEvents` config value to false.
+
+Then you need to manually trace these events.
+
+```swift
+FunPlusSDK.getFunPlusData().traceSessionStart()
+...
+FunPlusSDK.getFunPlusData().traceSessionEnd(sessionLength:)
+```
+
+Note that don't manually trace these events when `dataAutoTraceSessionEvents` is set to true.
 
 ## FAQ
 

--- a/Source/FunPlusConfig.swift
+++ b/Source/FunPlusConfig.swift
@@ -42,7 +42,7 @@ public class FunPlusConfig {
     let dataKey: String
     var dataUploadInterval: Int64
 
-    var autoSessionStartAndEnd: Bool
+    var dataAutoTraceSessionEvents: Bool
     
     // MARK: - Init
     
@@ -74,7 +74,7 @@ public class FunPlusConfig {
         self.dataKey = appKey
         self.dataUploadInterval = 30    // 30 sec
         
-        self.autoSessionStartAndEnd = true
+        self.dataAutoTraceSessionEvents = true
     }
     
     // Deprecated
@@ -134,7 +134,7 @@ public class FunPlusConfig {
         self.dataKey = dataKey
         self.dataUploadInterval = configDict["data_upload_interval"] as? Int64 ?? 10
         
-        self.autoSessionStartAndEnd = true
+        self.dataAutoTraceSessionEvents = true
     }
     
     public func setLoggerUploadInterval(_ value: Int64) -> FunPlusConfig {
@@ -172,8 +172,8 @@ public class FunPlusConfig {
         return self
     }
     
-    public func setAutoSessionStartAndEnd(_ value: Bool) -> FunPlusConfig {
-        autoSessionStartAndEnd = value
+    public func setDataAutoTraceSessionEvents(_ value: Bool) -> FunPlusConfig {
+        dataAutoTraceSessionEvents = value
         return self
     }
     

--- a/Source/FunPlusData.swift
+++ b/Source/FunPlusData.swift
@@ -127,7 +127,9 @@ public class FunPlusData: SessionStatusChangeListener {
         
         extraProperties = UserDefaults.standard.dictionary(forKey: FunPlusData.EXTRA_PROPERTIES_SAVED_KEY) as? [String: String] ?? [:]
         
-        FunPlusFactory.getSessionManager(funPlusConfig: funPlusConfig).registerListener(listener: self)
+        if funPlusConfig.dataAutoTraceSessionEvents {
+            FunPlusFactory.getSessionManager(funPlusConfig: funPlusConfig).registerListener(listener: self)
+        }
         
         getLogger().i("FunPlusData ready to work")
     }

--- a/Tests/FunPlusConfigTests.swift
+++ b/Tests/FunPlusConfigTests.swift
@@ -52,7 +52,7 @@ class FunPlusConfigTests: XCTestCase {
         XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
         XCTAssertEqual(config.dataUploadInterval, DEFAULT_DATA_UPLOAD_INTERVAL, "dataUploadInterval should be \(DEFAULT_DATA_UPLOAD_INTERVAL)")
         
-        XCTAssertTrue(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be true")
+        XCTAssertTrue(config.dataAutoTraceSessionEvents, "dataAutoTraceSessionEvents should be true")
     }
     
     func testDefaultValuesForProductionEnvironment() {
@@ -85,7 +85,7 @@ class FunPlusConfigTests: XCTestCase {
         XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
         XCTAssertEqual(config.dataUploadInterval, DEFAULT_DATA_UPLOAD_INTERVAL, "dataUploadInterval should be \(DEFAULT_DATA_UPLOAD_INTERVAL)")
         
-        XCTAssertTrue(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be true")
+        XCTAssertTrue(config.dataAutoTraceSessionEvents, "dataAutoTraceSessionEvents should be true")
     }
     
     func testSettersChain() {
@@ -107,7 +107,7 @@ class FunPlusConfigTests: XCTestCase {
             .setRumUserWhitelist(rumUserWhitelist)
             .setRumUserBlacklist(rumUserBlacklist)
             .setDataUploadInterval(dataUploadInterval)
-            .setAutoSessionStartAndEnd(false)
+            .setDataAutoTraceSessionEvents(false)
             .end()
         
         // Then
@@ -136,7 +136,7 @@ class FunPlusConfigTests: XCTestCase {
         XCTAssertEqual(config.dataKey, APP_KEY, "dataKey should be \(APP_KEY)")
         XCTAssertEqual(config.dataUploadInterval, dataUploadInterval, "dataUploadInterval should be \(dataUploadInterval)")
         
-        XCTAssertFalse(config.autoSessionStartAndEnd, "autoSessionStartAndEnd should be false")
+        XCTAssertFalse(config.dataAutoTraceSessionEvents, "dataAutoTraceSessionEvents should be false")
     }
 
 }


### PR DESCRIPTION
If `dataAutoTraceSessionEvents` is set to false, SDK will not
automatically trace session events. Developer needs to trace
these events manually:

```
FunPlusSDK.getFunPlusData().traceSessionStart()
...
FunPlusSDK.getFunPlusData().traceSessionEnd(sessionLength:)
```

Closes #5