### PR TITLE
refactor(logclient): do not modify data queue in upload callback

### DIFF
--- a/Source/FunPlusData.swift
+++ b/Source/FunPlusData.swift
@@ -175,7 +175,7 @@ public class FunPlusData: SessionStatusChangeListener {
             }
             
             #if DEBUG
-                customTraceHistory.append(eventString: event.description, traceTime: Date())
+            customTraceHistory.append(eventString: event.description, traceTime: Date())
             #endif
         }
         

--- a/Source/LogAgentDataUploader.swift
+++ b/Source/LogAgentDataUploader.swift
@@ -16,7 +16,7 @@ class LogAgentDataUploader {
     // MARK: - Properties
     
     /// Max size of an upload batch.
-    let MAX_BATCH_SIZE = 100
+    static let MAX_BATCH_SIZE = 100
     
     /// The configurations.
     let funPlusConfig: FunPlusConfig
@@ -58,16 +58,16 @@ class LogAgentDataUploader {
         - parameter data:       The data set to be uploaded.
         - parameter completion: The completion callback.
      */
-    func upload(data: inout [[String: Any]], completion: @escaping (Int) -> Void) {
+    func upload(data: [[String: Any]], completion: @escaping (Bool) -> Void) {
         let total = data.count
         
         guard total > 0 else {
-            completion(0)
+            completion(false)
             return
         }
         
         // Batch size must not exceed MAX_BATCH_SIZE.
-        let batchSize = min(total, MAX_BATCH_SIZE)
+        let batchSize = min(total, LogAgentDataUploader.MAX_BATCH_SIZE)
         let subArray = Array(data[0..<batchSize])
         let batch = subArray.map { item -> String in
             do {
@@ -88,7 +88,7 @@ class LogAgentDataUploader {
         let requestBody = batch.joined(separator: "\n").data(using: String.Encoding.utf8)
 
         LogAgentDataUploader.request(url: url, data: requestBody!) { status in
-            completion(status ? batchSize : 0)
+            completion(status)
         }
     }
     
@@ -103,7 +103,7 @@ class LogAgentDataUploader {
     private class func request(
         url: String,
         data: Data,
-        completion: @escaping (_ status: Bool) -> ())
+        completion: @escaping (Bool) -> ())
     {
         // Compose the URL.
         guard let url = URL(string: url) else {

--- a/Tests/LogAgentDataUploaderTests.swift
+++ b/Tests/LogAgentDataUploaderTests.swift
@@ -31,11 +31,11 @@ class LogAgentDataUploaderTests: XCTestCase {
         
         let ex = expectation(description: "\(uploader)")
         
-        var resultUploaded: Int!
+        var status: Bool = false
         
         // When
-        uploader.upload(data: &dataQueue) { (uploaded) in
-            resultUploaded = uploaded
+        uploader.upload(data: dataQueue) { (s) in
+            status = s
             
             ex.fulfill()
         }
@@ -43,7 +43,7 @@ class LogAgentDataUploaderTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT, handler: nil)
         
         // Then
-        XCTAssertEqual(resultUploaded, testCount, "uploaded should be \(testCount)")
+        XCTAssertTrue(status, "uploaded should be successful")
     }
     
     func testUploadWithBadLogAgentTag() {
@@ -59,11 +59,11 @@ class LogAgentDataUploaderTests: XCTestCase {
         
         let ex = expectation(description: "\(uploader)")
         
-        var resultUploaded: Int!
+        var status: Bool = true
         
         // When
-        uploader.upload(data: &dataQueue) { (uploaded) in
-            resultUploaded = uploaded
+        uploader.upload(data: dataQueue) { (s) in
+            status = s
             
             ex.fulfill()
         }
@@ -71,7 +71,7 @@ class LogAgentDataUploaderTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT, handler: nil)
         
         // Then
-        XCTAssertEqual(resultUploaded, 0, "uploaded should be 0")
+        XCTAssertFalse(status, "uploaded should be failed")
     }
 
     func testNetworkOff() {
@@ -87,11 +87,11 @@ class LogAgentDataUploaderTests: XCTestCase {
         
         let ex = expectation(description: "\(uploader)")
         
-        var resultUploaded: Int!
+        var status: Bool = true
         
         // When
-        uploader.upload(data: &dataQueue) { (uploaded) in
-            resultUploaded = uploaded
+        uploader.upload(data: dataQueue) { (s) in
+            status = s
             
             ex.fulfill()
         }
@@ -99,6 +99,6 @@ class LogAgentDataUploaderTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT, handler: nil)
         
         // Then
-        XCTAssertEqual(resultUploaded, 0, "uploaded should be 0")
+        XCTAssertFalse(status, "uploaded should be failed")
     }
 }


### PR DESCRIPTION
This commit contains the following changes:

1. When calling `uploader.upload()`, use a copied data queue;
2. Remove modifications on data queue in upload callback;
3. Remove network listener in `LogAgentClient`;
4. Remove `isUploading` and `isOffline` in `LogAgentClient`.

Closes #15