### PR TITLE
refactor(rum): remove `traceHistory` from RUM and Data

### DIFF
--- a/Source/FunPlusData.swift
+++ b/Source/FunPlusData.swift
@@ -73,14 +73,6 @@ public class FunPlusData: SessionStatusChangeListener {
     /// User-defined properties.
     var extraProperties: [String: String]
     
-    #if DEBUG
-    /// History of traced KPI events.
-    var kpiTraceHistory = [(eventString: String, traceTime: Date)]()
-    
-    /// History of traced custom events.
-    var customTraceHistory = [(eventString: String, traceTime: Date)]()
-    #endif
-    
     // MARK: - Init
     
     /**
@@ -162,10 +154,6 @@ public class FunPlusData: SessionStatusChangeListener {
             for listener in listeners {
                 listener.kpiEventTraced(event: event)
             }
-            
-            #if DEBUG
-            kpiTraceHistory.append(eventString: event.description, traceTime: Date())
-            #endif
         case .custom:
             customLogAgentClient.trace(entry: event)
             
@@ -173,10 +161,6 @@ public class FunPlusData: SessionStatusChangeListener {
             for listener in listeners {
                 listener.customEventTraced(event: event)
             }
-            
-            #if DEBUG
-            customTraceHistory.append(eventString: event.description, traceTime: Date())
-            #endif
         }
         
         getLogger().i("Trace Data event: \(event)")

--- a/Tests/FunPlusDataTests.swift
+++ b/Tests/FunPlusDataTests.swift
@@ -9,6 +9,19 @@
 import XCTest
 @testable import FunPlusSDK
 
+class DataEventListener : DataEventTracedListener {
+    var kpiTraceHistory = [(eventString: String, traceTime: Date)]()
+    var customTraceHistory = [(eventString: String, traceTime: Date)]()
+    
+    func kpiEventTraced(event: [String: Any]) {
+        kpiTraceHistory.append(eventString: event.description, traceTime: Date())
+    }
+    
+    func customEventTraced(event: [String: Any]) {
+        customTraceHistory.append(eventString: event.description, traceTime: Date())
+    }
+}
+
 class FunPlusDataTests: XCTestCase {
     
     let TIMEOUT = 10.0
@@ -18,11 +31,13 @@ class FunPlusDataTests: XCTestCase {
     func testTrace() {
         // Given, When
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
         tracer.traceSessionStart()
         
         // Then
-        XCTAssertEqual(tracer.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.kpiTraceHistory[0].eventString
+        XCTAssertEqual(listener.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.kpiTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("session_start"), "session_start should be contained")
@@ -44,13 +59,15 @@ class FunPlusDataTests: XCTestCase {
     func testTraceSessionStart() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
         
         // When
         tracer.traceSessionStart()
         
         // Then
-        XCTAssertEqual(tracer.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.kpiTraceHistory[0].eventString
+        XCTAssertEqual(listener.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.kpiTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("session_start"), "session_start should be contained")
@@ -72,13 +89,15 @@ class FunPlusDataTests: XCTestCase {
     func testTraceSessionEnd() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
         
         // When
         tracer.traceSessionEnd(sessionLength: 100)
         
         // Then
-        XCTAssertEqual(tracer.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.kpiTraceHistory[0].eventString
+        XCTAssertEqual(listener.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.kpiTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("session_end"), "session_end should be contained")
@@ -100,13 +119,15 @@ class FunPlusDataTests: XCTestCase {
     func testTraceNewUser() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
         
         // When
         tracer.traceNewUser()
         
         // Then
-        XCTAssertEqual(tracer.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.kpiTraceHistory[0].eventString
+        XCTAssertEqual(listener.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.kpiTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("new_user"), "new_user should be contained")
@@ -128,6 +149,9 @@ class FunPlusDataTests: XCTestCase {
     func testTracePayment() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let amount = 399.0
         let currency = "USD"
         let productId = "com.funplus.barnvoyage.jewelBox.270"
@@ -152,8 +176,8 @@ class FunPlusDataTests: XCTestCase {
         )
         
         // Then
-        XCTAssertEqual(tracer.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.kpiTraceHistory[0].eventString
+        XCTAssertEqual(listener.kpiTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.kpiTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("payment"), "payment should be contained")
@@ -183,6 +207,9 @@ class FunPlusDataTests: XCTestCase {
     func testTraceCustom() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let customEvent: [String: Any] = [
             "event":        "plant",
             "data_version": "2.0",
@@ -205,8 +232,8 @@ class FunPlusDataTests: XCTestCase {
         tracer.traceCustom(event: customEvent)
         
         // Then
-        XCTAssertEqual(tracer.customTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.customTraceHistory[0].eventString
+        XCTAssertEqual(listener.customTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.customTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("plant"), "plant should be contained")
@@ -228,6 +255,9 @@ class FunPlusDataTests: XCTestCase {
     func testTraceCustomEventWithNameAndProperties() {
         // Given
         let tracer = FunPlusData(funPlusConfig: funPlusConfig)
+        let listener = DataEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let eventName = "plant"
         let properties: [String: Any] = [
             "m1": [
@@ -240,8 +270,8 @@ class FunPlusDataTests: XCTestCase {
         tracer.traceCustom(eventName: eventName, properties: properties)
         
         // Then
-        XCTAssertEqual(tracer.customTraceHistory.count, 1, "traceHistory.count should be 1")
-        let event = tracer.customTraceHistory[0].eventString
+        XCTAssertEqual(listener.customTraceHistory.count, 1, "traceHistory.count should be 1")
+        let event = listener.customTraceHistory[0].eventString
         
         XCTAssertTrue(event.contains("event"), "event should be contained")
         XCTAssertTrue(event.contains("plant"), "plant should be contained")

--- a/Tests/FunPlusRUMTests.swift
+++ b/Tests/FunPlusRUMTests.swift
@@ -9,6 +9,19 @@
 import XCTest
 @testable import FunPlusSDK
 
+class RUMEventListener : RUMEventTracedListener {
+    var traceHistory = [(eventString: String, traceTime: Date)]()
+    var suppressHistory = [(eventString: String, traceTime: Date)]()
+    
+    func eventTraced(event: [String: Any]) {
+        traceHistory.append(eventString: event.description, traceTime: Date())
+    }
+    
+    func eventSuppressed(event: [String: Any]) {
+        suppressHistory.append(eventString: event.description, traceTime: Date())
+    }
+}
+
 class FunPlusRUMTests: XCTestCase {
     
     let TIMEOUT = 10.0
@@ -18,16 +31,22 @@ class FunPlusRUMTests: XCTestCase {
     func testTrace() {
         // Given, When
         let tracer = FunPlusRUM(funPlusConfig: funPlusConfig)
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         tracer.traceAppBackground()
         
         // Then
-        XCTAssertEqual(tracer.traceHistory.count, 1, "traceHistory.count should be 1")
-        XCTAssertTrue(tracer.traceHistory[0].eventString.contains("app_background"), "event should be app_background")
+        XCTAssertEqual(listener.traceHistory.count, 1, "traceHistory.count should be 1")
+        XCTAssertTrue(listener.traceHistory[0].eventString.contains("app_background"), "event should be app_background")
     }
     
     func testTraceNetworkSwtich() {
         // Given
         let tracer = FunPlusRUM(funPlusConfig: funPlusConfig)
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let sourceState = "3G"
         let currentState = "Wifi"
         
@@ -35,13 +54,16 @@ class FunPlusRUMTests: XCTestCase {
         tracer.traceNetworkSwitch(sourceState: sourceState, currentState: currentState)
         
         // Then
-        XCTAssertEqual(tracer.traceHistory.count, 1, "traceHistory.count should be 1")
-        XCTAssertTrue(tracer.traceHistory[0].eventString.contains("network_switch"), "event should be network_switch")
+        XCTAssertEqual(listener.traceHistory.count, 1, "traceHistory.count should be 1")
+        XCTAssertTrue(listener.traceHistory[0].eventString.contains("network_switch"), "event should be network_switch")
     }
     
     func testTraceServiceMonitoring() {
         // Given
         let tracer = FunPlusRUM(funPlusConfig: funPlusConfig)
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let serviceName = "testservice"
         let httpUrl = "http://url.com"
         let httpStatus = "200"
@@ -70,13 +92,16 @@ class FunPlusRUMTests: XCTestCase {
         )
         
         // Then
-        XCTAssertEqual(tracer.traceHistory.count, 1, "traceHistory.count should be 1")
-        XCTAssertTrue(tracer.traceHistory[0].eventString.contains("service_monitoring"), "event should be service_monitoring")
+        XCTAssertEqual(listener.traceHistory.count, 1, "traceHistory.count should be 1")
+        XCTAssertTrue(listener.traceHistory[0].eventString.contains("service_monitoring"), "event should be service_monitoring")
     }
     
     func testAppDidBecomeActive() {
         // Given
         let tracer = FunPlusRUM(funPlusConfig: funPlusConfig)
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let ex = expectation(description: "\(tracer)")
         
         // When
@@ -89,13 +114,16 @@ class FunPlusRUMTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT, handler: nil)
         
         // Then
-        XCTAssertEqual(tracer.traceHistory.count, 1, "traceHistory.count should be 1")
-        XCTAssertTrue(tracer.traceHistory[0].eventString.contains("app_foreground"), "event should be app_foreground")
+        XCTAssertEqual(listener.traceHistory.count, 1, "traceHistory.count should be 1")
+        XCTAssertTrue(listener.traceHistory[0].eventString.contains("app_foreground"), "event should be app_foreground")
     }
     
     func testAppDidEnterBackground() {
         // Given
         let tracer = FunPlusRUM(funPlusConfig: funPlusConfig)
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
+        
         let ex = expectation(description: "\(tracer)")
         
         // When
@@ -109,20 +137,22 @@ class FunPlusRUMTests: XCTestCase {
         waitForExpectations(timeout: TIMEOUT, handler: nil)
         
         // Then
-        XCTAssertEqual(tracer.traceHistory.count, 2, "traceHistory.count should be 2")
-        XCTAssertTrue(tracer.traceHistory[0].eventString.contains("app_foreground"), "app_foreground should be app_foreground")
-        XCTAssertTrue(tracer.traceHistory[1].eventString.contains("app_background"), "app_foreground should be app_background")
+        XCTAssertEqual(listener.traceHistory.count, 2, "traceHistory.count should be 2")
+        XCTAssertTrue(listener.traceHistory[0].eventString.contains("app_foreground"), "app_foreground should be app_foreground")
+        XCTAssertTrue(listener.traceHistory[1].eventString.contains("app_background"), "app_foreground should be app_background")
     }
     
     func testSuppressHistory() {
         // Given
         let tracer = FunPlusRUM(funPlusConfig: FunPlusConfigFactory.rumSampleRateZeroConfig())
+        let listener = RUMEventListener()
+        tracer.registerEventTracedListener(listener: listener)
         
         // When
         tracer.traceAppBackground()
         
         // Then
-        XCTAssertEqual(tracer.suppressHistory.count, 1, "suppressHistory.count should be 1")
-        XCTAssertTrue(tracer.suppressHistory[0].eventString.contains("app_background"), "event should be app_background")
+        XCTAssertEqual(listener.suppressHistory.count, 1, "suppressHistory.count should be 1")
+        XCTAssertTrue(listener.suppressHistory[0].eventString.contains("app_background"), "event should be app_background")
     }
 }


### PR DESCRIPTION
This commit made these changes:

1. Remove `tracedHistory` and `suppressedHistory` from RUM;
2. Remove `kpiTracedHistory` and `customTracedHistory` from Data;
3. Modify test cases to fit these code changes.

Closes #25